### PR TITLE
Check for missing data before filtering

### DIFF
--- a/gcMapExplorer/lib/ccmapHelpers.pyx
+++ b/gcMapExplorer/lib/ccmapHelpers.pyx
@@ -207,7 +207,7 @@ def get_nonzeros_index(matrix, threshold_percentile=None, threshold_data_occup=N
 		raise AssertionError("Both 'threshold_percentile' and 'threshold_count_ratio' cannot be used simultaneously!")
 
 	# Make false if number of zeros is less than threshold
-	if threshold_percentile is not None:
+	if threshold_percentile is not None and zero_count.any():
 		percentile = np.percentile(zero_count[zero_count != 0], threshold_percentile)
 		# print( (zero_count==0).sum(), zero_count.shape, percentile,  np.amin(zero_count[zero_count > 0]), np.amax(zero_count))
 		for i in range(mx):
@@ -220,7 +220,7 @@ def get_nonzeros_index(matrix, threshold_percentile=None, threshold_data_occup=N
 					#print(i, zero_count[i], percentile)
 
 	# Make false if number of zeros is less than threshold
-	if threshold_data_occup is not None:
+	if threshold_data_occup is not None and zero_count.any():
 		for i in range(mx):
 			if bData[i]:
 				if zero_count[i]/mx >=  (1.0 - threshold_data_occup):


### PR DESCRIPTION
Bug fix for:

```python3
gcMapExplorer.lib.ccmapHelpers.get_nonzeros_index(matrix, percentile_threshold_no_data=99)
```

When there are no zeros in the input matrix, the functions throws:

```
  File "/home/chbk/.local/lib/python3.6/site-packages/gcMapExplorer/lib/normalizer.py", line 395, in normalizeCCMapByKR
    raise e
  File "/home/chbk/.local/lib/python3.6/site-packages/gcMapExplorer/lib/normalizer.py", line 327, in normalizeCCMapByKR
    bNonZeros = cmh.get_nonzeros_index(ccMapObj.matrix, threshold_percentile=percentile_threshold_no_data, threshold_data_occup=threshold_data_occup)
  File "gcMapExplorer/lib/ccmapHelpers.pyx", line 211, in gcMapExplorer.lib.ccmapHelpers.get_nonzeros_index
  File "/home/chbk/.local/lib/python3.6/site-packages/numpy/lib/function_base.py", line 3707, in percentile
    a, q, axis, out, overwrite_input, interpolation, keepdims)
  File "/home/chbk/.local/lib/python3.6/site-packages/numpy/lib/function_base.py", line 3826, in _quantile_unchecked
    interpolation=interpolation)
  File "/home/chbk/.local/lib/python3.6/site-packages/numpy/lib/function_base.py", line 3405, in _ureduce
    r = func(a, **kwargs)
  File "/home/chbk/.local/lib/python3.6/site-packages/numpy/lib/function_base.py", line 3941, in _quantile_ureduce_func
    x1 = take(ap, indices_below, axis=axis) * weights_below
  File "/home/chbk/.local/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 189, in take
    return _wrapfunc(a, 'take', indices, axis=axis, out=out, mode=mode)
  File "/home/chbk/.local/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 56, in _wrapfunc
    return getattr(obj, method)(*args, **kwds)
IndexError: cannot do a non-empty take from an empty axes.
```

This is because the [`zero_count`](https://github.com/rjdkmr/gcMapExplorer/blob/58653b4f15ac3eab5211e718838b083cf09d81a7/gcMapExplorer/lib/ccmapHelpers.pyx#L211) variable is an array of zeros in that case, and numpy cannot determine a percentile from it.

Checking that `zero_count` actually has non-zero entries before filtering solves this issue.