### PR TITLE
box-forced deprecated in matplotlib

### DIFF
--- a/gcMapExplorer/gui/browser.py
+++ b/gcMapExplorer/gui/browser.py
@@ -986,10 +986,10 @@ class Main(QMainWindow, Ui_MainWindow, GenomicDataSetSubPlotHelper):
         while i < len(self.hiCmapAxes):
             if i == 0:
                 ax = self.figure.add_subplot(1, mid_idx, i+1)
-                ax.set_aspect('equal', 'box-forced')
+                ax.set_aspect('equal', 'box')
             else:
                 ax = self.figure.add_subplot(1, mid_idx, i+1, sharey=self.hiCmapAxes[0].ax)
-                ax.set_aspect('equal', 'box-forced')
+                ax.set_aspect('equal', 'box')
             self.hiCmapAxes[i].update_axes(ax) # Replotted both ccmap and any subplots here
             self.ActiveHiCmapAxis = i
             i = i+1
@@ -1236,13 +1236,13 @@ class Main(QMainWindow, Ui_MainWindow, GenomicDataSetSubPlotHelper):
                         Therefore, for first one, axes is generated differently.
                     '''
                     ax = self.figure.add_subplot(1, mid_idx, i+1)
-                    ax.set_aspect('equal', 'box-forced')
+                    ax.set_aspect('equal', 'box')
                     ax.set_xlim(0, self.binsDisplayed)
                 else:
                     ''' Other axes-plots share its axis with first plot.
                     '''
                     ax = self.figure.add_subplot(1, mid_idx, i+1, sharey=self.hiCmapAxes[0].ax)
-                    ax.set_aspect('equal', 'box-forced')
+                    ax.set_aspect('equal', 'box')
                     ax.set_xlim(0, self.binsDisplayed)
 
                 # Update axes_props object with new axes object. Also, plot is updated here
@@ -1251,7 +1251,7 @@ class Main(QMainWindow, Ui_MainWindow, GenomicDataSetSubPlotHelper):
 
             # Add new axes object for new ccmap
             ax = self.figure.add_subplot(1, mid_idx, i+1, sharey=self.hiCmapAxes[0].ax)
-            ax.set_aspect('equal', 'box-forced')
+            ax.set_aspect('equal', 'box')
             self.hiCmapAxes.append(CCMAPAXIS(i, ax, parent=self))
 
             # generate title


### PR DESCRIPTION
When adding more than one Hi-C map in the explorer following error occurs:
```
Traceback (most recent call last):
  File "/home/lucas/.local/lib/python3.6/site-packages/gcMapExplorer/gui/browser.py", line 1469, in load_map_file
    self.add_new_ccmap_axes(filename)
  File "/home/lucas/.local/lib/python3.6/site-packages/gcMapExplorer/gui/browser.py", line 1239, in add_new_ccmap_axes
    ax.set_aspect('equal', 'box-forced')
  File "/home/lucas/.local/lib/python3.6/site-packages/matplotlib/axes/_base.py", line 1295, in set_aspect
    self.set_adjustable(adjustable, share=share)  # Handle sharing.
  File "/home/lucas/.local/lib/python3.6/site-packages/matplotlib/axes/_base.py", line 1335, in set_adjustable
    cbook._check_in_list(["box", "datalim"], adjustable=adjustable)
  File "/home/lucas/.local/lib/python3.6/site-packages/matplotlib/cbook/__init__.py", line 2164, in _check_in_list
    .format(v, k, ', '.join(map(repr, values))))
ValueError: 'box-forced' is not a valid value for adjustable; supported values are 'box', 'datalim'
```

In newer versions of matplotlib `box-forced` is deprecated (not sure which version). Now simply `box` should be used.